### PR TITLE
Make OutputChannel optional.

### DIFF
--- a/examples/extension/lib/extension.js
+++ b/examples/extension/lib/extension.js
@@ -18,7 +18,7 @@ const { getLogger, initLogger } = require("./logger-wrapper");
 function activate(context) {
   // The `logPath` is only available from the `ExtensionContext`
   const logPath = context.logPath;
-
+  const logOutputChannel = window.createOutputChannel(meta.name);
   const logLevelSetting = getLoggingLevelSetting();
   const sourceLocationTrackingSettings = getSourceLocationTrackingSetting();
   const meta = require(resolve(__dirname, "..", "package.json"));
@@ -28,6 +28,7 @@ function activate(context) {
     extName: meta.name,
     level: logLevelSetting,
     logPath: logPath,
+    logOutputChannel: logOutputChannel,
     sourceLocationTracking: sourceLocationTrackingSettings
   });
 

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -39,12 +39,13 @@ function activate(context) {
     extName: "MyExtName",
     level: "info", // See LogLevel type in @vscode-logging/types for possible logLevels
     logPath: context.logPath, // The logPath is only available from the `vscode.ExtensionContext`
+    logOutputChannel: logOutputChannel, // OutputChannel for the logger
     sourceLocationTracking: false
   });
 
   extLogger.warn("Hello World");
   // Will Log The following entry to **both**
-  //   - VSCode outputChannel named "MyExtName"
+  //   - VSCode outputChannel `logOutputChannel`
   //   - To log files in `logPath`
   // {
   //   "label": "MyExtName",

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -45,7 +45,7 @@ function activate(context) {
 
   extLogger.warn("Hello World");
   // Will Log The following entry to **both**
-  //   - VSCode outputChannel `logOutputChannel`
+  //   - To outputChannel `logOutputChannel`
   //   - To log files in `logPath`
   // {
   //   "label": "MyExtName",

--- a/packages/logger/api.d.ts
+++ b/packages/logger/api.d.ts
@@ -4,6 +4,8 @@
  * - VSCode OutputChannel
  */
 import { IVSCodeExtLogger, LogLevel } from "@vscode-logging/types";
+import { OutputChannel } from "vscode";
+
 export {
   IVSCodeExtLogger,
   IChildLogger,
@@ -51,4 +53,9 @@ export type getExtensionLoggerOpts = {
    * Will likely cause significant performance regressions in productive flows.
    */
   sourceLocationTracking?: boolean;
+  /**
+   * Optional Output channel where the logs should be shown.
+   * If this is not passed no Output channel will be used.
+   */
+  logOutputChannel?: OutputChannel;
 };

--- a/packages/logger/lib/api.js
+++ b/packages/logger/lib/api.js
@@ -67,23 +67,13 @@ function getExtensionLogger(opts) {
     transports: transports
   });
 
-  let extLogger;
-  if (opts.logOutputChannel) {
-    extLogger = new VSCodeExtLogger({
-      label: opts.extName,
-      level: opts.level,
-      loggerImpel: rootWinstonLogger,
-      outChannel: opts.logOutputChannel,
-      sourceLocationTracking: opts.sourceLocationTracking
-    });
-  } else {
-    extLogger = new VSCodeExtLogger({
-      label: opts.extName,
-      level: opts.level,
-      loggerImpel: rootWinstonLogger,
-      sourceLocationTracking: opts.sourceLocationTracking
-    });
-  }
+  const extLogger = new VSCodeExtLogger({
+    label: opts.extName,
+    level: opts.level,
+    loggerImpel: rootWinstonLogger,
+    outChannel: opts.logOutputChannel || undefined,
+    sourceLocationTracking: opts.sourceLocationTracking
+  });
 
   return extLogger;
 }

--- a/packages/logger/lib/api.js
+++ b/packages/logger/lib/api.js
@@ -1,3 +1,4 @@
+const { isEmpty } = require("lodash");
 const { createLogger } = require("winston");
 /**
  * Normally we would prefer to depend upon `vscode` and `streamroller` inside their respective transports.
@@ -29,8 +30,10 @@ function getExtensionLogger(opts) {
     throw Error(`Attempt to use unknown logging level: <${opts.level}>!`);
   }
 
-  if (!opts.logOutputChannel && !opts.logPath) {
-    throw Error("Should have at least one: logOutputChannel or logPath");
+  if (isEmpty(opts.logOutputChannel) && isEmpty(opts.logPath)) {
+    throw Error(
+      "Logger must have at least one logging target defined, either logOutputChannel or logPath."
+    );
   }
 
   /**

--- a/packages/logger/lib/api.js
+++ b/packages/logger/lib/api.js
@@ -71,7 +71,7 @@ function getExtensionLogger(opts) {
     label: opts.extName,
     level: opts.level,
     loggerImpel: rootWinstonLogger,
-    outChannel: opts.logOutputChannel || undefined,
+    outChannel: opts.logOutputChannel,
     sourceLocationTracking: opts.sourceLocationTracking
   });
 

--- a/packages/logger/lib/api.js
+++ b/packages/logger/lib/api.js
@@ -1,4 +1,4 @@
-const { isEmpty } = require("lodash");
+const { has } = require("lodash");
 const { createLogger } = require("winston");
 /**
  * Normally we would prefer to depend upon `vscode` and `streamroller` inside their respective transports.
@@ -30,7 +30,7 @@ function getExtensionLogger(opts) {
     throw Error(`Attempt to use unknown logging level: <${opts.level}>!`);
   }
 
-  if (isEmpty(opts.logOutputChannel) && isEmpty(opts.logPath)) {
+  if (!has(opts, "logOutputChannel") && !has(opts, "logPath")) {
     throw Error(
       "Logger must have at least one logging target defined, either logOutputChannel or logPath."
     );

--- a/packages/logger/lib/api.js
+++ b/packages/logger/lib/api.js
@@ -30,6 +30,10 @@ function getExtensionLogger(opts) {
     throw Error(`Attempt to use unknown logging level: <${opts.level}>!`);
   }
 
+  if (!opts.logOutputChannel && !opts.logPath) {
+    throw Error("Should have at least one: logOutputChannel or logPath");
+  }
+
   // We are creating the output channel here because we also need a reference to it in the
   // VSCodeExtLogger instance.
   const outChannel = window.createOutputChannel(opts.extName);

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -166,7 +166,7 @@ class VSCodeExtLogger extends BaseLogger {
   constructor(opts) {
     super(opts);
 
-    this[OUT_CHANNEL] = opts.outChannel;
+    this[OUT_CHANNEL] = opts.outChannel || undefined;
     this.changeLevel(opts.level);
     this[WARN_IF_LOCATION_TRACKING_IS_ENABLED]();
   }
@@ -194,7 +194,10 @@ VSCodeExtLogger.prototype[WARN_IF_LOCATION_TRACKING_IS_ENABLED] = function() {
     this.fatal(
       "SourceLocationTracking is Enabled, This must only be used during debugging flows as it causes performance regressions"
     );
-    this[OUT_CHANNEL].show();
+
+    if (this[OUT_CHANNEL]) {
+      this[OUT_CHANNEL].show();
+    }
   }
 };
 

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -159,8 +159,8 @@ class VSCodeExtLogger extends BaseLogger {
    * @param {object} opts
    * @param {string} opts.label
    * @param {string} opts.level
-   * @param {import("vscode").OutputChannel} opts.outChannel
    * @param {import("winston").Logger} opts.loggerImpel
+   * @param {import("vscode").OutputChannel} [opts.outChannel]
    * @param {boolean} [opts.sourceLocationTracking]
    */
   constructor(opts) {

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -20,11 +20,11 @@
     "streamroller": "2.2.3",
     "triple-beam": "1.3.0",
     "winston": "3.2.1",
-    "winston-transport": "4.3.0"
+    "winston-transport": "4.3.0",
+    "@types/vscode": "^1.41.0"
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
-    "@types/vscode": "^1.41.0",
     "proxyquire": "2.1.3"
   },
   "scripts": {

--- a/packages/logger/test/api-spec.js
+++ b/packages/logger/test/api-spec.js
@@ -1,0 +1,33 @@
+const { expect } = require("chai");
+const proxyquire = require("proxyquire").noCallThru();
+
+const { levels, levelsConfig } = require("../lib/levels");
+const { VSCodeStub } = require("./stubs/vscode-stub");
+
+describe("VSCode Extension Logger", () => {
+  /**
+   * @type {typeof import("../api").getExtensionLogger}
+   */
+  let getExtensionLogger;
+  let vsCodeStub;
+  beforeEach(() => {
+    // VSCode outChannel is always enabled so we still need a stub for it
+    // even if we are only interested in the rolling File Logger
+    vsCodeStub = new VSCodeStub();
+    const mainModuleStubbed = proxyquire("../lib/api.js", {
+      vscode: vsCodeStub
+    });
+    getExtensionLogger = mainModuleStubbed.getExtensionLogger;
+  });
+
+  context("when receiving no OutputChannel and no logPath", () => {
+    it("will throw on invalid/missing parameters", () => {
+      expect(() => {
+        getExtensionLogger({
+          extName: "MyExtName",
+          level: "error"
+        });
+      }).to.throw("Should have at least one: logOutputChannel or logPath");
+    });
+  });
+});

--- a/packages/logger/test/api-spec.js
+++ b/packages/logger/test/api-spec.js
@@ -11,8 +11,8 @@ describe("VSCode Extension Logger", () => {
   let getExtensionLogger;
   let vsCodeStub;
   beforeEach(() => {
-    // VSCode outChannel is always enabled so we still need a stub for it
-    // even if we are only interested in the rolling File Logger
+    // VSCode outChannel is optional but we still need a stub for it
+    // in order to test its functionality
     vsCodeStub = new VSCodeStub();
     const mainModuleStubbed = proxyquire("../lib/api.js", {
       vscode: vsCodeStub

--- a/packages/logger/test/api-spec.js
+++ b/packages/logger/test/api-spec.js
@@ -1,24 +1,10 @@
 const { expect } = require("chai");
-const proxyquire = require("proxyquire").noCallThru();
-
-const { levels, levelsConfig } = require("../lib/levels");
-const { VSCodeStub } = require("./stubs/vscode-stub");
+const { getExtensionLogger } = require("../lib/api.js");
 
 describe("VSCode Extension Logger", () => {
   /**
    * @type {typeof import("../api").getExtensionLogger}
    */
-  let getExtensionLogger;
-  let vsCodeStub;
-  beforeEach(() => {
-    // VSCode outChannel is optional but we still need a stub for it
-    // in order to test its functionality
-    vsCodeStub = new VSCodeStub();
-    const mainModuleStubbed = proxyquire("../lib/api.js", {
-      vscode: vsCodeStub
-    });
-    getExtensionLogger = mainModuleStubbed.getExtensionLogger;
-  });
 
   context("when receiving no OutputChannel and no logPath", () => {
     it("will throw on invalid/missing parameters", () => {

--- a/packages/logger/test/api-spec.js
+++ b/packages/logger/test/api-spec.js
@@ -13,7 +13,7 @@ describe("VSCode Extension Logger", () => {
           extName: "MyExtName",
           level: "error"
         });
-      }).to.throw("Should have at least one: logOutputChannel or logPath");
+      }).to.throw(" logOutputChannel or logPath");
     });
   });
 });

--- a/packages/logger/test/child-logger-spec.js
+++ b/packages/logger/test/child-logger-spec.js
@@ -24,7 +24,8 @@ describe("VSCode Extension Logger", () => {
     it("will log to childLogger", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });
@@ -45,7 +46,8 @@ describe("VSCode Extension Logger", () => {
     it("will handle logging level at the root Logger of all childLoggers", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });
@@ -72,7 +74,8 @@ describe("VSCode Extension Logger", () => {
     it("will handle sourceLocationTracking option at the root Logger of all childLoggers", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "info"
+        level: "info",
+        logPath: "logPath"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });
@@ -100,7 +103,8 @@ describe("VSCode Extension Logger", () => {
     it("will cache and re-use the same childLogger for the same label", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });

--- a/packages/logger/test/child-logger-spec.js
+++ b/packages/logger/test/child-logger-spec.js
@@ -24,8 +24,8 @@ describe("VSCode Extension Logger", () => {
     it("will log to childLogger", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });
@@ -46,8 +46,8 @@ describe("VSCode Extension Logger", () => {
     it("will handle logging level at the root Logger of all childLoggers", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });
@@ -74,8 +74,8 @@ describe("VSCode Extension Logger", () => {
     it("will handle sourceLocationTracking option at the root Logger of all childLoggers", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "info",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "info"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });
@@ -103,8 +103,8 @@ describe("VSCode Extension Logger", () => {
     it("will cache and re-use the same childLogger for the same label", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
 
       const childLogger = extLogger.getChildLogger({ label: "myLibName" });

--- a/packages/logger/test/child-logger-spec.js
+++ b/packages/logger/test/child-logger-spec.js
@@ -12,8 +12,8 @@ describe("VSCode Extension Logger", () => {
     let getExtensionLogger;
     let vsCodeStub;
     beforeEach(() => {
-      // VSCode outChannel is always enabled so we still need a stub for it
-      // even if we are only interested in the rolling File Logger
+      // VSCode outChannel is optional but we still need a stub for it
+      // in order to test its functionality
       vsCodeStub = new VSCodeStub();
       const mainModuleStubbed = proxyquire("../lib/api.js", {
         vscode: vsCodeStub

--- a/packages/logger/test/levels-spec.js
+++ b/packages/logger/test/levels-spec.js
@@ -26,8 +26,8 @@ describe("VSCode Extension Logger", () => {
       expect(() => {
         getExtensionLogger({
           extName: "MyExtName",
-          level: "Emergency", // This is a sysLog severity
-          logPath: "logPath"
+          logOutputChannel: vsCodeStub.OutputChannel,
+          level: "Emergency" // This is a sysLog severity
         });
       }).to.throw("Attempt to use unknown logging level: <Emergency>!");
     });
@@ -35,8 +35,8 @@ describe("VSCode Extension Logger", () => {
     it(`will warn and ignore on subsequent invalid level`, () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "fatal",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "fatal"
       });
 
       extLogger.changeLevel("Emergency");
@@ -89,8 +89,8 @@ describe("VSCode Extension Logger", () => {
       it(`will only log correct levels in '${currLevel}'`, () => {
         const extLogger = getExtensionLogger({
           extName: "MyExtName",
-          level: currLevel,
-          logPath: "logPath"
+          logOutputChannel: vsCodeStub.OutputChannel,
+          level: currLevel
         });
 
         // try logging using all the possible levels

--- a/packages/logger/test/levels-spec.js
+++ b/packages/logger/test/levels-spec.js
@@ -26,7 +26,8 @@ describe("VSCode Extension Logger", () => {
       expect(() => {
         getExtensionLogger({
           extName: "MyExtName",
-          level: "Emergency" // This is a sysLog severity
+          level: "Emergency", // This is a sysLog severity
+          logPath: "logPath"
         });
       }).to.throw("Attempt to use unknown logging level: <Emergency>!");
     });
@@ -34,7 +35,8 @@ describe("VSCode Extension Logger", () => {
     it(`will warn and ignore on subsequent invalid level`, () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "fatal"
+        level: "fatal",
+        logPath: "logPath"
       });
 
       extLogger.changeLevel("Emergency");
@@ -87,7 +89,8 @@ describe("VSCode Extension Logger", () => {
       it(`will only log correct levels in '${currLevel}'`, () => {
         const extLogger = getExtensionLogger({
           extName: "MyExtName",
-          level: currLevel
+          level: currLevel,
+          logPath: "logPath"
         });
 
         // try logging using all the possible levels

--- a/packages/logger/test/levels-spec.js
+++ b/packages/logger/test/levels-spec.js
@@ -12,8 +12,8 @@ describe("VSCode Extension Logger", () => {
   let getExtensionLogger;
   let vsCodeStub;
   beforeEach(() => {
-    // VSCode outChannel is always enabled so we still need a stub for it
-    // even if we are only interested in the rolling File Logger
+    // VSCode outChannel is optional but we still need a stub for it
+    // in order to test its functionality
     vsCodeStub = new VSCodeStub();
     const mainModuleStubbed = proxyquire("../lib/api.js", {
       vscode: vsCodeStub

--- a/packages/logger/test/log-methods-apis-spec.js
+++ b/packages/logger/test/log-methods-apis-spec.js
@@ -24,7 +24,8 @@ describe("VSCode Extension extLogger", () => {
     it("supports splat arguments", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
 
       extLogger.fatal("hello %s and 1 + %i equals 2", "world", 1);
@@ -35,7 +36,8 @@ describe("VSCode Extension extLogger", () => {
     it("supports metadata object arguments", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
 
       extLogger.fatal("hello world", { a: 666, b: "oops" }, { c: 333 });
@@ -48,7 +50,8 @@ describe("VSCode Extension extLogger", () => {
     it("supports combining splat and object arguments", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
 
       extLogger.fatal("hello %s", "world", { a: 666, b: "oops" }, { c: 333 });

--- a/packages/logger/test/log-methods-apis-spec.js
+++ b/packages/logger/test/log-methods-apis-spec.js
@@ -12,8 +12,8 @@ describe("VSCode Extension extLogger", () => {
     let getExtensionLogger;
     let vsCodeStub;
     beforeEach(() => {
-      // VSCode outChannel is always enabled so we still need a stub for it
-      // even if we are only interested in the rolling File extLogger
+      // VSCode outChannel is optional but we still need a stub for it
+      // in order to test its functionality
       vsCodeStub = new VSCodeStub();
       const mainModuleStubbed = proxyquire("../lib/api.js", {
         vscode: vsCodeStub

--- a/packages/logger/test/log-methods-apis-spec.js
+++ b/packages/logger/test/log-methods-apis-spec.js
@@ -7,7 +7,7 @@ const { VSCodeStub } = require("./stubs/vscode-stub");
 describe("VSCode Extension extLogger", () => {
   context("Log Methods APIs and Argument Types", () => {
     /**
-     * @type {typeof import("../api").getExtensionLogger}
+     * @type {typeof import("../api").getExtensionLogger}output
      */
     let getExtensionLogger;
     let vsCodeStub;

--- a/packages/logger/test/log-methods-apis-spec.js
+++ b/packages/logger/test/log-methods-apis-spec.js
@@ -24,8 +24,8 @@ describe("VSCode Extension extLogger", () => {
     it("supports splat arguments", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
 
       extLogger.fatal("hello %s and 1 + %i equals 2", "world", 1);
@@ -36,8 +36,8 @@ describe("VSCode Extension extLogger", () => {
     it("supports metadata object arguments", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
 
       extLogger.fatal("hello world", { a: 666, b: "oops" }, { c: 333 });
@@ -49,9 +49,8 @@ describe("VSCode Extension extLogger", () => {
 
     it("supports combining splat and object arguments", () => {
       const extLogger = getExtensionLogger({
-        extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
 
       extLogger.fatal("hello %s", "world", { a: 666, b: "oops" }, { c: 333 });

--- a/packages/logger/test/out-channel-spec.js
+++ b/packages/logger/test/out-channel-spec.js
@@ -24,8 +24,8 @@ describe("VSCode Extension Logger", () => {
     it("will Log in JSON Format", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
       extLogger.fatal("Oy Vey!");
       extLogger.error("Oh Dear...");
@@ -51,8 +51,8 @@ describe("VSCode Extension Logger", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
         sourceLocationTracking: true,
-        level: "error",
-        logPath: "logPath"
+        logOutputChannel: vsCodeStub.OutputChannel,
+        level: "error"
       });
       extLogger.fatal("Oh dear");
       const logEntries = map(vsCodeStub.lines, JSON.parse);
@@ -68,15 +68,6 @@ describe("VSCode Extension Logger", () => {
       expect(logJsonEntry.source.location).to.match(fileNameAndLocRegExp);
     });
 
-    it("will Create an outChannel named after the extension", () => {
-      getExtensionLogger({
-        extName: "MyExtName",
-        level: "error",
-        logPath: "logPath"
-      });
-      expect(vsCodeStub.channelName).to.equal("MyExtName");
-    });
-
     context(
       "will **show** on the outChannel and log a warning when the sourceLocationTracking is enabled",
       () => {
@@ -84,8 +75,8 @@ describe("VSCode Extension Logger", () => {
           getExtensionLogger({
             extName: "MyExtName",
             sourceLocationTracking: true,
-            level: "warn",
-            logPath: "logPath"
+            logOutputChannel: vsCodeStub.OutputChannel,
+            level: "warn"
           });
           expect(vsCodeStub.shown).to.be.true;
         });
@@ -93,8 +84,8 @@ describe("VSCode Extension Logger", () => {
         it("on sourceLocationChange change", () => {
           const extLogger = getExtensionLogger({
             extName: "MyExtName",
-            level: "error",
-            logPath: "logPath"
+            logOutputChannel: vsCodeStub.OutputChannel,
+            level: "error"
           });
           expect(vsCodeStub.shown).to.be.false;
           extLogger.changeSourceLocationTracking(true);

--- a/packages/logger/test/out-channel-spec.js
+++ b/packages/logger/test/out-channel-spec.js
@@ -24,7 +24,8 @@ describe("VSCode Extension Logger", () => {
     it("will Log in JSON Format", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
       extLogger.fatal("Oy Vey!");
       extLogger.error("Oh Dear...");
@@ -50,7 +51,8 @@ describe("VSCode Extension Logger", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
         sourceLocationTracking: true,
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
       extLogger.fatal("Oh dear");
       const logEntries = map(vsCodeStub.lines, JSON.parse);
@@ -69,7 +71,8 @@ describe("VSCode Extension Logger", () => {
     it("will Create an outChannel named after the extension", () => {
       getExtensionLogger({
         extName: "MyExtName",
-        level: "error"
+        level: "error",
+        logPath: "logPath"
       });
       expect(vsCodeStub.channelName).to.equal("MyExtName");
     });
@@ -81,7 +84,8 @@ describe("VSCode Extension Logger", () => {
           getExtensionLogger({
             extName: "MyExtName",
             sourceLocationTracking: true,
-            level: "warn"
+            level: "warn",
+            logPath: "logPath"
           });
           expect(vsCodeStub.shown).to.be.true;
         });
@@ -89,7 +93,8 @@ describe("VSCode Extension Logger", () => {
         it("on sourceLocationChange change", () => {
           const extLogger = getExtensionLogger({
             extName: "MyExtName",
-            level: "error"
+            level: "error",
+            logPath: "logPath"
           });
           expect(vsCodeStub.shown).to.be.false;
           extLogger.changeSourceLocationTracking(true);

--- a/packages/logger/test/rolling-file-spec.js
+++ b/packages/logger/test/rolling-file-spec.js
@@ -21,8 +21,8 @@ describe("VSCode Extension Logger", () => {
     let streamRollerStub;
     let vsCodeStub;
     beforeEach(() => {
-      // VSCode outChannel is always enabled so we still need a stub for it
-      // even if we are only interested in the rolling File Logger
+      // VSCode outChannel is optional but we still need a stub for it
+      // in order to test its functionality
       vsCodeStub = new VSCodeStub();
       streamRollerStub = new StreamRollerStub();
       const mainModuleStubbed = proxyquire("../lib/api.js", {

--- a/packages/logger/test/rolling-file-spec.js
+++ b/packages/logger/test/rolling-file-spec.js
@@ -19,10 +19,11 @@ describe("VSCode Extension Logger", () => {
      */
     let getExtensionLogger;
     let streamRollerStub;
+    let vsCodeStub;
     beforeEach(() => {
       // VSCode outChannel is always enabled so we still need a stub for it
       // even if we are only interested in the rolling File Logger
-      const vsCodeStub = new VSCodeStub();
+      vsCodeStub = new VSCodeStub();
       streamRollerStub = new StreamRollerStub();
       const mainModuleStubbed = proxyquire("../lib/api.js", {
         vscode: vsCodeStub,
@@ -35,6 +36,7 @@ describe("VSCode Extension Logger", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
         logPath: TESTS_LOG_PATH,
+        logOutputChannel: vsCodeStub.OutputChannel,
         level: "error"
       });
       extLogger.fatal("Oy Vey!");
@@ -62,6 +64,7 @@ describe("VSCode Extension Logger", () => {
         extName: "MyExtName",
         sourceLocationTracking: true,
         logPath: TESTS_LOG_PATH,
+        logOutputChannel: vsCodeStub.OutputChannel,
         level: "error"
       });
       extLogger.fatal("Oy Vey!");

--- a/packages/logger/test/rolling-file-spec.js
+++ b/packages/logger/test/rolling-file-spec.js
@@ -63,6 +63,7 @@ describe("VSCode Extension Logger", () => {
         extName: "MyExtName",
         sourceLocationTracking: true,
         logPath: TESTS_LOG_PATH,
+        logOutputChannel: vsCodeStub.OutputChannel,
         level: "error"
       });
       extLogger.fatal("Oy Vey!");

--- a/packages/logger/test/rolling-file-spec.js
+++ b/packages/logger/test/rolling-file-spec.js
@@ -3,7 +3,6 @@ const { expect } = require("chai");
 const proxyquire = require("proxyquire").noCallThru();
 const { basename, resolve } = require("path");
 
-const { VSCodeStub } = require("./stubs/vscode-stub");
 const { StreamRollerStub } = require("./stubs/stream-roller-stub");
 
 const TESTS_LOG_PATH = resolve(__dirname, ".log-out");
@@ -19,14 +18,9 @@ describe("VSCode Extension Logger", () => {
      */
     let getExtensionLogger;
     let streamRollerStub;
-    let vsCodeStub;
     beforeEach(() => {
-      // VSCode outChannel is optional but we still need a stub for it
-      // in order to test its functionality
-      vsCodeStub = new VSCodeStub();
       streamRollerStub = new StreamRollerStub();
       const mainModuleStubbed = proxyquire("../lib/api.js", {
-        vscode: vsCodeStub,
         streamroller: streamRollerStub
       });
       getExtensionLogger = mainModuleStubbed.getExtensionLogger;

--- a/packages/logger/test/rolling-file-spec.js
+++ b/packages/logger/test/rolling-file-spec.js
@@ -63,7 +63,6 @@ describe("VSCode Extension Logger", () => {
         extName: "MyExtName",
         sourceLocationTracking: true,
         logPath: TESTS_LOG_PATH,
-        logOutputChannel: vsCodeStub.OutputChannel,
         level: "error"
       });
       extLogger.fatal("Oy Vey!");

--- a/packages/logger/test/rolling-file-spec.js
+++ b/packages/logger/test/rolling-file-spec.js
@@ -36,7 +36,6 @@ describe("VSCode Extension Logger", () => {
       const extLogger = getExtensionLogger({
         extName: "MyExtName",
         logPath: TESTS_LOG_PATH,
-        logOutputChannel: vsCodeStub.OutputChannel,
         level: "error"
       });
       extLogger.fatal("Oy Vey!");
@@ -64,7 +63,6 @@ describe("VSCode Extension Logger", () => {
         extName: "MyExtName",
         sourceLocationTracking: true,
         logPath: TESTS_LOG_PATH,
-        logOutputChannel: vsCodeStub.OutputChannel,
         level: "error"
       });
       extLogger.fatal("Oy Vey!");

--- a/packages/logger/test/stubs/vscode-stub.js
+++ b/packages/logger/test/stubs/vscode-stub.js
@@ -1,22 +1,16 @@
 class VSCodeStub {
   constructor() {
-    this.channelName = undefined;
     this.lines = [];
     this.shown = false;
 
     const that = this;
-    this.window = {
-      createOutputChannel(extName) {
-        that.channelName = extName;
-        return {
-          dispose: () => {},
-          show: () => {
-            that.shown = true;
-          },
-          appendLine: txt => {
-            that.lines.push(txt);
-          }
-        };
+    this.OutputChannel = {
+      dispose: () => {},
+      show: () => {
+        that.shown = true;
+      },
+      appendLine: txt => {
+        that.lines.push(txt);
       }
     };
   }


### PR DESCRIPTION
Remove OutputChannel creation and add OutputChannel as an optional parameter. It will allow the VS Code Extension to write logs to the files only and not to Output channel.

OutputChannel will not be created inside the logger as today. Alternatively, it will be added as an optional parameter. The VS Code Extension will be able to create the OutputChannel and send it to the logger as a parameter.