### PR TITLE
Standard output stream

### DIFF
--- a/examples/extension/lib/extension.js
+++ b/examples/extension/lib/extension.js
@@ -29,7 +29,8 @@ function activate(context) {
     level: logLevelSetting,
     logPath: logPath,
     logOutputChannel: logOutputChannel,
-    sourceLocationTracking: sourceLocationTrackingSettings
+    sourceLocationTracking: sourceLocationTrackingSettings,
+    logConsole: true
   });
 
   // Update our logger-wrapper with a reference to the extLogger.
@@ -43,6 +44,10 @@ function activate(context) {
 
   // Simple Dependency Injection example of using the VSCode Logger in a "consumed" npm library/package.
   callLibraryAndPassLogger();
+
+  getLogger().info(`Testing logging info level`);
+  getLogger().warn(`Testing logging warn level`);
+  getLogger().error(`Testing logging error level`);
 
   registerCommands(context);
 

--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -40,7 +40,8 @@ function activate(context) {
     level: "info", // See LogLevel type in @vscode-logging/types for possible logLevels
     logPath: context.logPath, // The logPath is only available from the `vscode.ExtensionContext`
     logOutputChannel: logOutputChannel, // OutputChannel for the logger
-    sourceLocationTracking: false
+    sourceLocationTracking: false,
+    logConsol: false // define if messages should be logged to the consol
   });
 
   extLogger.warn("Hello World");

--- a/packages/logger/api.d.ts
+++ b/packages/logger/api.d.ts
@@ -20,7 +20,6 @@ export type getExtensionLoggerOpts = {
   /**
    * This parameter will be used for two things:
    *
-   * - Name of the VSCode OutputChannel to log to.
    *
    * - Root Label used when creating log entries.
    *   This will also be used as the prefix label for any childLogger e.g:
@@ -58,4 +57,11 @@ export type getExtensionLoggerOpts = {
    * If this is not passed no Output channel will be used.
    */
   logOutputChannel?: OutputChannel;
+  /**
+   * Optional Console output channel, if set to true the log message will be printed to the Console output stream (stdout/stderr in Linux)
+   * Error and Fatal messages are printed to the standard error console
+   * Warn, Info, Debug and Trace are printed to the standard output console
+   * Default = false
+   */
+  logConsole?: boolean;
 };

--- a/packages/logger/lib/logger.js
+++ b/packages/logger/lib/logger.js
@@ -9,6 +9,7 @@ const LABEL = Symbol("label");
 const LOGGER_IMPEL = Symbol("loggerImpel");
 const LEVEL_INT = Symbol("levelInt");
 const SOURCE_LOCATION_TRACKING = Symbol("sourceLocationTracking");
+const CONSOLE_OUTPUT = Symbol("consoleOutput");
 const CHILD_LOGGERS = Symbol("childLoggers");
 const OUT_CHANNEL = Symbol("outChannel");
 const WARN_IF_LOCATION_TRACKING_IS_ENABLED = Symbol(
@@ -21,6 +22,7 @@ class BaseLogger {
    * @param {string} opts.label
    * @param {string} opts.level
    * @param {boolean} [opts.sourceLocationTracking]
+   * @param {boolean} [opts.consoleOutput]
    * @param {import("winston").Logger} opts.loggerImpel
    */
   constructor(opts) {
@@ -29,7 +31,7 @@ class BaseLogger {
     this[LEVEL_INT] = levelsConfig[opts.level];
     // disabled by default as this may cause performance regressions
     this[SOURCE_LOCATION_TRACKING] = opts.sourceLocationTracking || false;
-
+    this[CONSOLE_OUTPUT] = opts.consoleOutput || false;
     // Possible memory leak if users forget to release their childLogger Resources
     // Could have been resolved using WeakMap, however Weak Collections in JavaScript are not iterable (yet)
     // So they are insufficient for our needs (see `getChildLogger` method).
@@ -47,6 +49,7 @@ class BaseLogger {
     const newChildLoggerImpel = new BaseLogger({
       label: newLabel,
       sourceLocationTracking: this[SOURCE_LOCATION_TRACKING],
+      consoleOutput: this[CONSOLE_OUTPUT],
       level: findKey(levelsConfig, val => val === this[LEVEL_INT]),
       loggerImpel: this[LOGGER_IMPEL]
     });
@@ -153,6 +156,7 @@ class VSCodeExtLogger extends BaseLogger {
    * @param {import("winston").Logger} opts.loggerImpel
    * @param {import("vscode").OutputChannel} [opts.outChannel]
    * @param {boolean} [opts.sourceLocationTracking]
+   * @param {boolean} [opts.consoleOutput]
    */
   constructor(opts) {
     super(opts);

--- a/packages/logger/lib/transports/console-output.js
+++ b/packages/logger/lib/transports/console-output.js
@@ -1,0 +1,39 @@
+const Transport = require("winston-transport");
+const { LEVEL, MESSAGE } = require("triple-beam");
+
+class ConsoleTransport extends Transport {
+  constructor() {
+    super();
+  }
+
+  /**
+   * Core logging method exposed to Winston.
+   * @param {Object} info
+   * @param {Function} callback
+   */
+  log(info, callback) {
+    setImmediate(() => this.emit("logged", info));
+
+    switch (info[LEVEL]) {
+      case "error":
+      case "fatal":
+        console.error(info[MESSAGE]);
+        break;
+      case "warn":
+        console.warn(info[MESSAGE]);
+        break;
+      default:
+        console.log(info[MESSAGE]);
+    }
+    /* istanbul ignore else - winston transports use guard conditions around the callbacks
+     *  however I have no idea how to simulate the callback not existing... (winston internals...)
+     **/
+    if (callback) {
+      callback(); // eslint-disable-line callback-return
+    }
+  }
+}
+
+module.exports = {
+  ConsoleTransport: ConsoleTransport
+};

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -25,7 +25,9 @@
   },
   "devDependencies": {
     "@types/fs-extra": "^8.0.1",
-    "proxyquire": "2.1.3"
+    "proxyquire": "2.1.3",
+    "sinon": "^9.0.2",
+    "sinon-chai": "^3.5.0"
   },
   "scripts": {
     "ci": "npm-run-all type-check coverage:*",

--- a/packages/logger/test/api-spec.js
+++ b/packages/logger/test/api-spec.js
@@ -13,7 +13,7 @@ describe("VSCode Extension Logger", () => {
           extName: "MyExtName",
           level: "error"
         });
-      }).to.throw(" logOutputChannel or logPath");
+      }).to.throw("logOutputChannel, logPath and logConsole");
     });
   });
 });

--- a/packages/logger/test/console-output-spec.js
+++ b/packages/logger/test/console-output-spec.js
@@ -1,0 +1,105 @@
+const proxyquire = require("proxyquire").noCallThru();
+const chai = require("chai");
+const sinonChai = require("sinon-chai");
+const sinon = require("sinon");
+const { StreamRollerStub } = require("./stubs/stream-roller-stub");
+const { resolve } = require("path");
+
+chai.use(sinonChai);
+
+const expect = chai.expect;
+
+const TESTS_LOG_PATH = resolve(__dirname, ".log-out");
+
+describe("VSCode Extension Logger", function() {
+  let vsCodeStub;
+  /**
+   * @type {typeof import("../api").getExtensionLogger}
+   */
+  let getExtensionLogger;
+  let errSpy, warnSpy, logSpy;
+  let streamRollerStub;
+  beforeEach(() => {
+    streamRollerStub = new StreamRollerStub();
+    const mainModuleStubbed = proxyquire("../lib/api.js", {
+      streamroller: streamRollerStub
+    });
+    getExtensionLogger = mainModuleStubbed.getExtensionLogger;
+    errSpy = sinon.spy(console, "error");
+    warnSpy = sinon.spy(console, "warn");
+    logSpy = sinon.spy(console, "log");
+  });
+
+  afterEach(function() {
+    console.error.restore();
+    console.warn.restore();
+    console.log.restore();
+  });
+
+  describe("Console Logging - check that the output stream match the message type and log level - error/warn/info and stdout/stderr", function() {
+    it("should log to console in info level", function() {
+      const extLogger = getExtensionLogger({
+        extName: "MyExtName",
+        level: "info",
+        logConsole: true
+      });
+      extLogger.fatal("Oy Vey!");
+      extLogger.error("Oh Dear...");
+      extLogger.info("Oh Wow...");
+
+      sinon.assert.calledTwice(console.error);
+      sinon.assert.called(console.log);
+      sinon.assert.notCalled(console.warn);
+      expect(errSpy.args[0][0]).to.include("Oy Vey!");
+      expect(errSpy.args[1][0]).to.include("Oh Dear...");
+      expect(logSpy.args[0][0]).to.include("Oh Wow...");
+    });
+
+    it("should log to console in error level", function() {
+      const extLogger = getExtensionLogger({
+        extName: "MyExtName",
+        level: "error",
+        logConsole: true
+      });
+      extLogger.fatal("Oy Vey!");
+      extLogger.error("Oh Dear...");
+      extLogger.info("Oh Wow...");
+
+      sinon.assert.calledTwice(console.error);
+      sinon.assert.notCalled(console.log);
+      sinon.assert.notCalled(console.warn);
+      expect(errSpy.args[0][0]).to.include("Oy Vey!");
+      expect(errSpy.args[1][0]).to.include("Oh Dear...");
+    });
+
+    it("should log to console in warn level", function() {
+      const extLogger = getExtensionLogger({
+        extName: "MyExtName",
+        level: "warn",
+        logConsole: true
+      });
+      extLogger.warn("Oy Might...");
+      extLogger.error("Oh Dear...");
+      extLogger.info("Oh Wow...");
+
+      sinon.assert.called(console.error);
+      sinon.assert.called(console.warn);
+      sinon.assert.notCalled(console.log);
+      expect(errSpy.args[0][0]).to.include("Oh Dear...");
+      expect(warnSpy.args[0][0]).to.include("Oy Might...");
+    });
+
+    it("should not log to console when consoleOutput is false", function() {
+      const extLogger = getExtensionLogger({
+        extName: "MyExtName",
+        logPath: TESTS_LOG_PATH,
+        level: "info"
+      });
+      extLogger.fatal("Oy Vey!");
+      extLogger.info("Oy Wow!");
+      sinon.assert.notCalled(console.error);
+      sinon.assert.notCalled(console.warn);
+      sinon.assert.notCalled(console.log);
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,6 +1120,42 @@
   dependencies:
     any-observable "^0.3.0"
 
+"@sinonjs/commons@^1", "@sinonjs/commons@^1.6.0", "@sinonjs/commons@^1.7.0", "@sinonjs/commons@^1.7.2":
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
+  integrity sha512-892K+kWUUi3cl+LlqEWIDrhvLgdL79tECi8JZUyq6IviKy/DNhuzCRlbHUjxK89f4ypPMMaFnFuR9Ie6DoIMsw==
+  dependencies:
+    type-detect "4.0.8"
+
+"@sinonjs/fake-timers@^6.0.0", "@sinonjs/fake-timers@^6.0.1":
+  version "6.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/fake-timers/-/fake-timers-6.0.1.tgz#293674fccb3262ac782c7aadfdeca86b10c75c40"
+  integrity sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+
+"@sinonjs/formatio@^5.0.1":
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/formatio/-/formatio-5.0.1.tgz#f13e713cb3313b1ab965901b01b0828ea6b77089"
+  integrity sha512-KaiQ5pBf1MpS09MuA0kp6KBQt2JUOQycqVG1NZXvzeaXe5LGFqAKueIS0bw4w0P9r7KuBSVdUk5QjXsUdu2CxQ==
+  dependencies:
+    "@sinonjs/commons" "^1"
+    "@sinonjs/samsam" "^5.0.2"
+
+"@sinonjs/samsam@^5.0.2", "@sinonjs/samsam@^5.0.3":
+  version "5.0.3"
+  resolved "https://registry.yarnpkg.com/@sinonjs/samsam/-/samsam-5.0.3.tgz#86f21bdb3d52480faf0892a480c9906aa5a52938"
+  integrity sha512-QucHkc2uMJ0pFGjJUDP3F9dq5dx8QIaqISl9QgwLOh6P9yv877uONPGXh/OH/0zmM3tW1JjuJltAZV2l7zU+uQ==
+  dependencies:
+    "@sinonjs/commons" "^1.6.0"
+    lodash.get "^4.4.2"
+    type-detect "^4.0.8"
+
+"@sinonjs/text-encoding@^0.7.1":
+  version "0.7.1"
+  resolved "https://registry.yarnpkg.com/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz#8da5c6530915653f3a1f38fd5f101d8c3f8079c5"
+  integrity sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==
+
 "@types/chai@4.2.7":
   version "4.2.7"
   resolved "https://registry.yarnpkg.com/@types/chai/-/chai-4.2.7.tgz#1c8c25cbf6e59ffa7d6b9652c78e547d9a41692d"
@@ -2435,6 +2471,11 @@ diff@3.5.0:
   version "3.5.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
   integrity sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==
+
+diff@^4.0.2:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 dir-glob@^2.2.2:
   version "2.2.2"
@@ -3820,6 +3861,11 @@ is-windows@^1.0.0, is-windows@^1.0.1, is-windows@^1.0.2:
   resolved "https://registry.yarnpkg.com/is-windows/-/is-windows-1.0.2.tgz#d1850eb9791ecd18e6182ce12a30f396634bb19d"
   integrity sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
 
+isarray@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/isarray/-/isarray-0.0.1.tgz#8a18acfca9a8f4177e09abfc6038939b05d1eedf"
+  integrity sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=
+
 isarray@1.0.0, isarray@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/isarray/-/isarray-1.0.0.tgz#bb935d48582cba168c06834957a54a3e07124f11"
@@ -3987,6 +4033,11 @@ jsprim@^1.2.2:
     extsprintf "1.3.0"
     json-schema "0.2.3"
     verror "1.10.0"
+
+just-extend@^4.0.2:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-4.1.0.tgz#7278a4027d889601640ee0ce0e5a00b992467da4"
+  integrity sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==
 
 kind-of@^3.0.2, kind-of@^3.0.3, kind-of@^3.2.0:
   version "3.2.2"
@@ -4696,6 +4747,17 @@ nice-try@^1.0.4:
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
 
+nise@^4.0.1:
+  version "4.0.4"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-4.0.4.tgz#d73dea3e5731e6561992b8f570be9e363c4512dd"
+  integrity sha512-bTTRUNlemx6deJa+ZyoCUTRvH3liK5+N6VQZ4NIw90AgDXY6iPnsqplNFf6STcj+ePk0H/xqxnP75Lr0J0Fq3A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.0"
+    "@sinonjs/fake-timers" "^6.0.0"
+    "@sinonjs/text-encoding" "^0.7.1"
+    just-extend "^4.0.2"
+    path-to-regexp "^1.7.0"
+
 node-environment-flags@1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/node-environment-flags/-/node-environment-flags-1.0.6.tgz#a30ac13621f6f7d674260a54dede048c3982c088"
@@ -5255,6 +5317,13 @@ path-parse@^1.0.6:
   version "1.0.6"
   resolved "https://registry.yarnpkg.com/path-parse/-/path-parse-1.0.6.tgz#d62dbb5679405d72c4737ec58600e9ddcf06d24c"
   integrity sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+
+path-to-regexp@^1.7.0:
+  version "1.8.0"
+  resolved "https://registry.yarnpkg.com/path-to-regexp/-/path-to-regexp-1.8.0.tgz#887b3ba9d84393e87a0a0b9f4cb756198b53548a"
+  integrity sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==
+  dependencies:
+    isarray "0.0.1"
 
 path-type@^1.0.0:
   version "1.1.0"
@@ -5915,6 +5984,24 @@ simple-swizzle@^0.2.2:
   dependencies:
     is-arrayish "^0.3.1"
 
+sinon-chai@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/sinon-chai/-/sinon-chai-3.5.0.tgz#c9a78304b0e15befe57ef68e8a85a00553f5c60e"
+  integrity sha512-IifbusYiQBpUxxFJkR3wTU68xzBN0+bxCScEaKMjBvAQERg6FnTTc1F17rseLb1tjmkJ23730AXpFI0c47FgAg==
+
+sinon@^9.0.2:
+  version "9.0.2"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-9.0.2.tgz#b9017e24633f4b1c98dfb6e784a5f0509f5fd85d"
+  integrity sha512-0uF8Q/QHkizNUmbK3LRFqx5cpTttEVXudywY9Uwzy8bTfZUhljZ7ARzSxnRHWYWtVTeh4Cw+tTb3iU21FQVO9A==
+  dependencies:
+    "@sinonjs/commons" "^1.7.2"
+    "@sinonjs/fake-timers" "^6.0.1"
+    "@sinonjs/formatio" "^5.0.1"
+    "@sinonjs/samsam" "^5.0.3"
+    diff "^4.0.2"
+    nise "^4.0.1"
+    supports-color "^7.1.0"
+
 slash@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
@@ -6557,7 +6644,7 @@ tweetnacl@^0.14.3, tweetnacl@~0.14.0:
   resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
   integrity sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
 
-type-detect@^4.0.0, type-detect@^4.0.5:
+type-detect@4.0.8, type-detect@^4.0.0, type-detect@^4.0.5, type-detect@^4.0.8:
   version "4.0.8"
   resolved "https://registry.yarnpkg.com/type-detect/-/type-detect-4.0.8.tgz#7646fb5f18871cfbb7749e69bd39a6388eb7450c"
   integrity sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==


### PR DESCRIPTION
Adding support for console stream messages.
When enabling the Console options, messages that are printed using this library will be logged to the console stream (e.g. stdout/stderr in Linux or Debug Console in VSCode)

The Console stream is optional, default=false

You can enable it by setting: "logConsole: true" in the constructor options

This feature can be useful when debugging your extension.