### PR TITLE
upgrade lodash version to 4.17.21 due to CVE 

### DIFF
--- a/packages/wrapper/package.json
+++ b/packages/wrapper/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@types/lodash": "^4.14.167",
     "@types/vscode": "1.52.0",
-    "lodash": "^4.17.20"
+    "lodash": "^4.17.21"
   },
   "scripts": {
     "ci": "npm-run-all clean compile coverage:*",


### PR DESCRIPTION
update lodash version because of CVE: https://www.whitesourcesoftware.com/vulnerability-database/CVE-2021-23337