### PR TITLE
Fix logger example

### DIFF
--- a/packages/logger/README.md
+++ b/packages/logger/README.md
@@ -41,7 +41,7 @@ function activate(context) {
     logPath: context.logPath, // The logPath is only available from the `vscode.ExtensionContext`
     logOutputChannel: logOutputChannel, // OutputChannel for the logger
     sourceLocationTracking: false,
-    logConsol: false // define if messages should be logged to the consol
+    logConsole: false // define if messages should be logged to the consol
   });
 
   extLogger.warn("Hello World");


### PR DESCRIPTION
The property `logConsol` does not exist, better `logConsole`